### PR TITLE
Fix segmentation fault on key retrieve using sdsdup and sdsfree

### DIFF
--- a/mybot.c
+++ b/mybot.c
@@ -52,15 +52,16 @@ void handleRequest(sqlite3 *dbhandle, BotRequest *br) {
 
     int reqlen = strlen(br->request);
     if (br->argc == 1 && reqlen && br->request[reqlen-1] == '?') {
-        char *copy = strdup(br->request);
+        sds copy = sdsdup(br->request);
+
         copy[reqlen-1] = 0;
         printf("Looking for key %s\n", copy);
         sds res = kvGet(dbhandle,copy);
         if (res) {
             botSendMessage(br->target,res,0);
+            sdsfree(res);
         }
-        sdsfree(res);
-        free(copy);
+        sdsfree(copy);
     }
 }
 


### PR DESCRIPTION
If I use the sample mybot.c implementation I get a segmentation fault on key retrieval.
If I set a key and then I try to retrieve it I get:
....Sent message IDs: chat_id:131178217 message_id:35

.0. fabio? | 

Errore di segmentazione

It seems to be fixed by using sdsdup and corresponding sdsfree for the request copy.
