### PR TITLE
Fix a bug in finding an object using special "*"

### DIFF
--- a/json_wrap.c
+++ b/json_wrap.c
@@ -113,7 +113,7 @@ cJSON *cJSON_Select(cJSON *o, const char *fmt, ...) {
                 }
                 /* Common path. */
                 if (tlen+len > JSEL_MAX_TOKEN) goto notfound;
-                memcpy(token+tlen,buf,len);
+                memcpy(token+tlen,s,len);
                 tlen += len;
                 p++;
                 continue;


### PR DESCRIPTION
Following code would otherwise print `Didn't find child "child_name"`

```
cJSON *root = cJSON_Parse("{\"child_name\": 123}");
printf("Name of child object: %s\n", root->child->string);

cJSON *child = cJSON_Select(root, ".*", root->child->string);
if (child == NULL) {
	printf("Didn't find child \"%s\"\n", root->child->string);
} else {
	printf("Found child \"%s\", value %f\n", child->string, child->valuedouble);
}
```