### PR TITLE
Fixed segmentation fault on key query (i.e. Foo?) on Linux

### DIFF
--- a/mybot.c
+++ b/mybot.c
@@ -1,5 +1,11 @@
+#if defined(__linux__)
+#define _DEFAULT_SOURCE
+#define _XOPEN_SOURCE 600
+#endif
+
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
 #include <unistd.h>
 


### PR DESCRIPTION
This patch fixes the following warnings:

```c
cc -g -ggdb -O2 -Wall -W -std=c11 \
        cJSON.c sds.c json_wrap.c sqlite_wrap.c botlib.c \
        mybot.c -o mybot -lpthread -lcurl -lsqlite3
mybot.c: In function ‘handleRequest’:
mybot.c:51:27: warning: implicit declaration of function ‘strcasecmp’; did you mean ‘strncmp’? [-Wimplicit-function-declaration]
   51 |     if (br->argc >= 3 && !strcasecmp(br->argv[1],"is")) {
      |                           ^~~~~~~~~~
      |                           strncmp
mybot.c:61:22: warning: implicit declaration of function ‘strdup’; did you mean ‘sdsdup’? [-Wimplicit-function-declaration]
   61 |         char *copy = strdup(br->request);
      |                      ^~~~~~
      |                      sdsdup
mybot.c:61:22: warning: initialization of ‘char *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
```
And a crash on mybot.c:62 ` copy[reqlen-1] = 0;` . This seems to be caused by the conversion to char * from int mentioned in the warning.